### PR TITLE
Adds capacity to enable http access on the controller

### DIFF
--- a/goaviatrix/controller.go
+++ b/goaviatrix/controller.go
@@ -1,0 +1,66 @@
+package goaviatrix
+
+import (
+	"encoding/json"
+	"errors"
+	"log"
+)
+
+// Controller Http Access enabled get result struct
+type ControllerHttpAccessResp struct {
+	Return bool   `json:"return"`
+	Result string `json:"result"`
+}
+
+func (c *Client) EnableHttpAccess() error {
+    url := "?CID=%s&action=config_http_access&operation=enable"
+	path := c.baseURL + fmt.Sprintf(url, c.CID)
+	resp, err := c.Get(c.baseURL, nil)
+	if err != nil {
+		return err
+	}
+	var data APIResp
+	if err = json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return err
+	}
+	if !data.Return {
+		return errors.New(data.Reason)
+	}
+	return nil
+}
+
+func (c *Client) DisableHttpAccess() error {
+    url := "?CID=%s&action=config_http_access&operation=disable"
+	path := c.baseURL + fmt.Sprintf(url, c.CID)
+	resp, err := c.Get(c.baseURL, nil)
+	if err != nil {
+		return err
+	}
+	var data APIResp
+	if err = json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return err
+	}
+	if !data.Return {
+		return errors.New(data.Reason)
+	}
+	return nil
+}
+
+func (c *Client) GetHttpAccessEnabled() (string,error) {
+    url := "?CID=%s&action=config_http_access&operation=get"
+	path := c.baseURL + fmt.Sprintf(url, c.CID)
+	resp, err := c.Get(c.baseURL, nil)
+	if err != nil {
+		return err
+	}
+	var data ControllerHttpAccessResp
+	if err = json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return err
+	}
+	if !data.Return {
+		return errors.New(data.Reason)
+	}
+	result := data.Result
+	return result
+}
+

--- a/goaviatrix/controller.go
+++ b/goaviatrix/controller.go
@@ -4,18 +4,20 @@ import (
 	"encoding/json"
 	"errors"
 	"log"
+	"fmt"
 )
 
 // Controller Http Access enabled get result struct
 type ControllerHttpAccessResp struct {
 	Return bool   `json:"return"`
 	Result string `json:"result"`
+	Reason  string        `json:"reason"`
 }
 
 func (c *Client) EnableHttpAccess() error {
     url := "?CID=%s&action=config_http_access&operation=enable"
 	path := c.baseURL + fmt.Sprintf(url, c.CID)
-	resp, err := c.Get(c.baseURL, nil)
+	resp, err := c.Get(path, nil)
 	if err != nil {
 		return err
 	}
@@ -24,6 +26,7 @@ func (c *Client) EnableHttpAccess() error {
 		return err
 	}
 	if !data.Return {
+		log.Printf("[ERROR] Error invoking controller %s",data.Reason)
 		return errors.New(data.Reason)
 	}
 	return nil
@@ -32,7 +35,7 @@ func (c *Client) EnableHttpAccess() error {
 func (c *Client) DisableHttpAccess() error {
     url := "?CID=%s&action=config_http_access&operation=disable"
 	path := c.baseURL + fmt.Sprintf(url, c.CID)
-	resp, err := c.Get(c.baseURL, nil)
+	resp, err := c.Get(path, nil)
 	if err != nil {
 		return err
 	}
@@ -41,6 +44,7 @@ func (c *Client) DisableHttpAccess() error {
 		return err
 	}
 	if !data.Return {
+		log.Printf("[ERROR] Error invoking controller %s",data.Reason)
 		return errors.New(data.Reason)
 	}
 	return nil
@@ -49,18 +53,19 @@ func (c *Client) DisableHttpAccess() error {
 func (c *Client) GetHttpAccessEnabled() (string,error) {
     url := "?CID=%s&action=config_http_access&operation=get"
 	path := c.baseURL + fmt.Sprintf(url, c.CID)
-	resp, err := c.Get(c.baseURL, nil)
+	resp, err := c.Get(path, nil)
 	if err != nil {
-		return err
+		return "",err
 	}
 	var data ControllerHttpAccessResp
 	if err = json.NewDecoder(resp.Body).Decode(&data); err != nil {
-		return err
+		return "",err
 	}
 	if !data.Return {
-		return errors.New(data.Reason)
+		log.Printf("[ERROR] Error invoking controller %s",data.Reason)
+		return "",errors.New(data.Reason)
 	}
 	result := data.Result
-	return result
+	return result,nil
 }
 


### PR DESCRIPTION
Supports the (undocumented) config_http_access action on the controller, required to set up the controller behind and ELB and have the ELB use HTTP on port 8080 as listener destination.