### PR TITLE
fixing vpc_net in gateway struct

### DIFF
--- a/goaviatrix/gateway.go
+++ b/goaviatrix/gateway.go
@@ -93,7 +93,7 @@ type Gateway struct {
 	TunnelType              string `form:"tunnel_type,omitempty" json:"tunnel_type,omitempty"`
 	VendorName              string `form:"vendor_name,omitempty" json:"vendor_name,omitempty"`
 	VpcID                   string `form:"vpc_id,omitempty" json:"vpc_id,omitempty"`
-	VpcNet                  string `form:"vpc_net,omitempty" json:"public_subnet,omitempty"`
+	VpcNet                  string `form:"vpc_net,omitempty" json:"gw_subnet_cidr,omitempty"`
 	VpcRegion               string `form:"vpc_reg,omitempty" json:"vpc_region,omitempty"`
 	VpcSplunkIPPort         string `form:"vpc_splunk_ip_port,omitempty" json:"vpc_splunk_ip_port,omitempty"`
 	VpcState                string `form:"vpc_state,omitempty" json:"vpc_state,omitempty"`


### PR DESCRIPTION
the json output field from the controller is 'gw_subnet_cidr'
public_subnet looks to be an input. Tested with our controller and in docs "Get Gateway Information":

https://s3-us-west-2.amazonaws.com/avx-apidoc/index.htm#_get_gateway_info

